### PR TITLE
Updated vars.yml description and cli task

### DIFF
--- a/C9XXX/vars.yml
+++ b/C9XXX/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
+  application_tar_path: /home/user/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   cv_switchport: interface <SWITCHPORT> # Example: interface GigabitEthernet1/0/24
   monitor_session_src: interface <MONITOR_SESSION_INTERFACE> both # Example: interface Gi1/0/2 - 24 both --OR-- vlan 507 rx
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10

--- a/C9XXX/vars.yml
+++ b/C9XXX/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
+  application_tar_path: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   cv_switchport: interface <SWITCHPORT> # Example: interface GigabitEthernet1/0/24
   monitor_session_src: interface <MONITOR_SESSION_INTERFACE> both # Example: interface Gi1/0/2 - 24 both --OR-- vlan 507 rx
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10

--- a/IC3000/vars.yml
+++ b/IC3000/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-IC3000-5.0.1.tar
+  application_tar_path: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10
 
   # common default values- can be changed if needed

--- a/IC3000/vars.yml
+++ b/IC3000/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-IC3000-5.0.1.tar
+  application_tar_path: /home/user/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10
 
   # common default values- can be changed if needed

--- a/IE3X00/vars.yml
+++ b/IE3X00/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-aarch64-5.0.1.tar
+  application_tar_path: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   cv_switchport: interface <SWITCHPORT> # Example: interface GigabitEthernet1/3
   monitor_session_src: interface <MONITOR_SESSION_INTERFACE> both # Example: interface GigabitEthernet 1/4 - 10 --OR-- vlan 507 rx
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10

--- a/IE3X00/vars.yml
+++ b/IE3X00/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-aarch64-5.0.1.tar
+  application_tar_path: /home/user/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   cv_switchport: interface <SWITCHPORT> # Example: interface GigabitEthernet1/3
   monitor_session_src: interface <MONITOR_SESSION_INTERFACE> both # Example: interface GigabitEthernet 1/4 - 10 --OR-- vlan 507 rx
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10

--- a/IE9300/vars.yml
+++ b/IE9300/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-aarch64-5.0.1.tar
+  application_tar_path: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   monitor_session_src: interface <MONITOR_SESSION_INTERFACE> both # Example: interface Gi1/0/2 - 24 both --OR-- vlan 507 rx
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10
 

--- a/IE9300/vars.yml
+++ b/IE9300/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-aarch64-5.0.1.tar
+  application_tar_path: /home/user/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   monitor_session_src: interface <MONITOR_SESSION_INTERFACE> both # Example: interface Gi1/0/2 - 24 both --OR-- vlan 507 rx
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10
 

--- a/IR1XXX/vars.yml
+++ b/IR1XXX/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-aarch64-5.0.1.tar
+  application_tar_path: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   monitor_session_src: interface <MONITOR_SESSION_VLAN> # Example: interface vlan 507 --OR-- GigabitEthernet 0/0/0
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10
   nat_outside_interface: interface <OUTSIDE_INTERFACE> # Example: interface GigabitEthernet 0/0/0

--- a/IR1XXX/vars.yml
+++ b/IR1XXX/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-aarch64-5.0.1.tar
+  application_tar_path: /home/user/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   monitor_session_src: interface <MONITOR_SESSION_VLAN> # Example: interface vlan 507 --OR-- GigabitEthernet 0/0/0
   ansible_controller_ip: <CONTROLLER_IP> # Example: 172.16.10.10
   nat_outside_interface: interface <OUTSIDE_INTERFACE> # Example: interface GigabitEthernet 0/0/0

--- a/IR8340/vars.yml
+++ b/IR8340/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
+  application_tar_path: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cisco-cyber-vision-sensor-management-ansible/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   routed_monitor_session_src: interface <ROUTED_MONITOR_SESSION_INTERFACE> # Example: interface GigabitEthernet0/0/0 # OR interface vlan 507
   switched_monitor_session_src: interface <SWITCHED_MONITOR_SESSION_INTERFACE> both # Example: interface GigabitEthernet0/1/0 - 10 both
   nat_outside_interface: interface <NAT_OUTSIDE_INTERFACE> # Example: GigabitEthernet 0/0/0

--- a/IR8340/vars.yml
+++ b/IR8340/vars.yml
@@ -1,7 +1,7 @@
 cv_details:
   # user specific values- change these to match your environment
   center_url: https://<CYBER_VISION_CENTER_URL> # Example: https://172.16.10.1
-  application_tar_path: ../cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Example: ../cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
+  application_tar_path: /home/user/cv_tar_files/<CV_SENSOR_TAR_FILE>.tar # Use the full path. Example: /home/user/cv_tar_files/CiscoCyberVision-IOx-x86-64-5.0.1.tar
   routed_monitor_session_src: interface <ROUTED_MONITOR_SESSION_INTERFACE> # Example: interface GigabitEthernet0/0/0 # OR interface vlan 507
   switched_monitor_session_src: interface <SWITCHED_MONITOR_SESSION_INTERFACE> both # Example: interface GigabitEthernet0/1/0 - 10 both
   nat_outside_interface: interface <NAT_OUTSIDE_INTERFACE> # Example: GigabitEthernet 0/0/0

--- a/roles/cybervision_sensor_cli/tasks/main.yml
+++ b/roles/cybervision_sensor_cli/tasks/main.yml
@@ -144,7 +144,7 @@
     - name: Copy the application tar file to the device
       cisco.ios.ios_command:
         commands:
-          - command: "copy scp://{{ cv_scp_username }}:{{ cv_scp_password }}@{{ ansible_controller_ip }}/{{ application_tar_path }} {{ storage }}"
+          - command: "copy scp://{{ cv_scp_username }}:{{ cv_scp_password }}@{{ ansible_controller_ip }}:{{ application_tar_path }} {{ storage }}"
             prompt: 'Destination filename \[{{ application_file[0] }}\]?'
             answer: "\r"
       vars:


### PR DESCRIPTION
With the current documentation, in vars.yml file, we are using ../path/to/tar/file.tar

However, using CLI method, the scp expects a full path with trailing slash /path/to/tar/file.tar
If we had a trailing slash, we have to update the scp command accordingly